### PR TITLE
Fudge openmp from homebrew's GCC 7.2

### DIFF
--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5A1FDC6F203F0B050065E0F5 /* libgifski.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E3FD619F201BD29E0087160A /* libgifski.a */; };
+		5A1FDC77203F0C6D0065E0F5 /* libgomp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A1FDC72203F0C6D0065E0F5 /* libgomp.a */; };
 		E339F011203820ED003B78FB /* Gifski.swift in Sources */ = {isa = PBXBuildFile; fileRef = E339F010203820ED003B78FB /* Gifski.swift */; };
 		E34798D01F882FB3003F9142 /* ProgressKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E34798CF1F882FB3003F9142 /* ProgressKit.framework */; };
 		E34798D11F882FB3003F9142 /* ProgressKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E34798CF1F882FB3003F9142 /* ProgressKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -73,6 +74,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5A1FDC72203F0C6D0065E0F5 /* libgomp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgomp.a; path = /usr/local/opt/gcc/lib/gcc/7/libgomp.a; sourceTree = "<group>"; };
 		E339F010203820ED003B78FB /* Gifski.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gifski.swift; sourceTree = "<group>"; };
 		E34798CF1F882FB3003F9142 /* ProgressKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ProgressKit.framework; path = Carthage/Build/Mac/ProgressKit.framework; sourceTree = "<group>"; };
 		E34798D41F882FEE003F9142 /* ProgressKit.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = ProgressKit.framework.dSYM; path = Carthage/Build/Mac/ProgressKit.framework.dSYM; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				E3FDC26D203F32DA00C00409 /* libresolv.tbd in Frameworks */,
 				5A1FDC6F203F0B050065E0F5 /* libgifski.a in Frameworks */,
 				E34798D01F882FB3003F9142 /* ProgressKit.framework in Frameworks */,
+				5A1FDC77203F0C6D0065E0F5 /* libgomp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,6 +113,7 @@
 		E317EE121F88305800359C57 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5A1FDC72203F0C6D0065E0F5 /* libgomp.a */,
 				E3FD61A6201BD3640087160A /* libresolv.tbd */,
 				E3FD61A4201BD2DA0087160A /* gifski.h */,
 				E34798D41F882FEE003F9142 /* ProgressKit.framework.dSYM */,
@@ -435,7 +439,10 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Gifski/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/usr/local/opt/gcc/lib/gcc/7,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.sindresorhus.Gifski;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Gifski/Gifski-Bridging-Header.h";
@@ -462,7 +469,10 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Gifski/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/usr/local/opt/gcc/lib/gcc/7,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.sindresorhus.Gifski;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Gifski/Gifski-Bridging-Header.h";

--- a/gifski-api/gifski.xcodeproj/project.pbxproj
+++ b/gifski-api/gifski.xcodeproj/project.pbxproj
@@ -59,7 +59,7 @@
 /* Begin PBXLegacyTarget section */
 		CA60FB6F97415B50F10B8D0B /* Cargo */ = {
 			isa = PBXLegacyTarget;
-			buildArgumentsString = "build $(CARGO_FLAGS)";
+			buildArgumentsString = "build $(CARGO_FLAGS) --features=openmp";
 			buildConfigurationList = CA6045D4FC1B1EBBFEF4C27E /* Build configuration list for PBXLegacyTarget "Cargo" */;
 			buildPhases = (
 			);
@@ -220,6 +220,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CARGO_FLAGS = "";
+				CC = "gcc-7";
 				CARGO_TARGET_DIR = "$(BUILD_DIR)/cargo-target";
 				CARGO_XCODE_PRODUCTS_DIR = "$(BUILD_DIR)/cargo-target/debug";
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -269,6 +270,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CARGO_FLAGS = "--release";
+				CC = "gcc-7";
 				CARGO_TARGET_DIR = "$(BUILD_DIR)/cargo-target";
 				CARGO_XCODE_PRODUCTS_DIR = "$(BUILD_DIR)/cargo-target/release";
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;


### PR DESCRIPTION
This should make it noticeably faster. However, it's a bit hacky since it needs to link with GCC's library, which brew puts wherever it wants. Maybe it could be improved with injection of `brew --prefix` somewhere in the config.