### PR TITLE
Drop the `fileURLKey`

### DIFF
--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -60,7 +60,7 @@ final class Gifski {
 			return
 		}
 
-		var progress = Progress(parent: .current(), userInfo: [.fileURLKey: conversion.output])
+		var progress = Progress(parent: .current())
 		progress.fileURL = conversion.output
 
 		g.setProgressCallback(context: &progress) { context in


### PR DESCRIPTION
We don't need to set both. According to comments in the Obj-C headers:

```objective-c
/*
 A URL identifying the item on which progress is being made. This is required for any NSProgress that is published using -publish to be reported to subscribers registered with +addSubscriberForFileURL:withPublishingHandler:
 If present, NSProgress will use the information to present more information in its localized description.
 This property sets a value in the userInfo dictionary.
 */
@property (nullable, copy) NSURL *fileURL API_AVAILABLE(macosx(10.13), ios(11.0), watchos(4.0), tvos(11.0));
```