### PR TITLE
Move view/model code out of AppDelegate into a WindowController

### DIFF
--- a/Gifski.xcodeproj/project.pbxproj
+++ b/Gifski.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		5A1FDC6F203F0B050065E0F5 /* libgifski.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E3FD619F201BD29E0087160A /* libgifski.a */; };
 		C2040B8920435871004EE259 /* GifskiWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2040B8820435871004EE259 /* GifskiWrapper.swift */; };
+		C2AFA91D204FFEFD00FC5A7F /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */; };
+		C2AFA91E204FFEFD00FC5A7F /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C2AFA91C204FFEFD00FC5A7F /* MainWindowController.xib */; };
 		E339F011203820ED003B78FB /* Gifski.swift in Sources */ = {isa = PBXBuildFile; fileRef = E339F010203820ED003B78FB /* Gifski.swift */; };
 		E34798D01F882FB3003F9142 /* ProgressKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E34798CF1F882FB3003F9142 /* ProgressKit.framework */; };
 		E34798D11F882FB3003F9142 /* ProgressKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E34798CF1F882FB3003F9142 /* ProgressKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -79,6 +81,8 @@
 
 /* Begin PBXFileReference section */
 		C2040B8820435871004EE259 /* GifskiWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = GifskiWrapper.swift; sourceTree = "<group>"; usesTabs = 1; };
+		C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
+		C2AFA91C204FFEFD00FC5A7F /* MainWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindowController.xib; sourceTree = "<group>"; };
 		E339F010203820ED003B78FB /* Gifski.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Gifski.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E34798CF1F882FB3003F9142 /* ProgressKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ProgressKit.framework; path = Carthage/Build/Mac/ProgressKit.framework; sourceTree = "<group>"; };
 		E34798D41F882FEE003F9142 /* ProgressKit.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = ProgressKit.framework.dSYM; path = Carthage/Build/Mac/ProgressKit.framework.dSYM; sourceTree = "<group>"; };
@@ -163,6 +167,8 @@
 				E3BF14CC1E5CD5A30049FD4B /* Gifski.entitlements */,
 				E3FD6190201BCBC30087160A /* Gifski-Bridging-Header.h */,
 				E3C3DB4E203F154300CB8BB9 /* Credits.rtf */,
+				C2AFA91B204FFEFD00FC5A7F /* MainWindowController.swift */,
+				C2AFA91C204FFEFD00FC5A7F /* MainWindowController.xib */,
 			);
 			path = Gifski;
 			sourceTree = "<group>";
@@ -280,6 +286,7 @@
 				E3AE628C1E5CD2F300035A2F /* MainMenu.xib in Resources */,
 				E3DF3E89203BD2B900055855 /* SavePanelAccessoryViewController.xib in Resources */,
 				E3C3DB4F203F154300CB8BB9 /* Credits.rtf in Resources */,
+				C2AFA91E204FFEFD00FC5A7F /* MainWindowController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -308,6 +315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E339F011203820ED003B78FB /* Gifski.swift in Sources */,
+				C2AFA91D204FFEFD00FC5A7F /* MainWindowController.swift in Sources */,
 				E3CB1DD71F7E4CBC00D79BFC /* VideoDropView.swift in Sources */,
 				C2040B8920435871004EE259 /* GifskiWrapper.swift in Sources */,
 				E3AE62871E5CD2F300035A2F /* AppDelegate.swift in Sources */,

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -8,7 +8,7 @@ extension NSColor {
 
 @NSApplicationMain
 final class AppDelegate: NSObject, NSApplicationDelegate {
-	var mainWindowController: MainWindowController!
+	var mainWindowController = MainWindowController()
 
 	var hasFinishedLaunching = false
 	var urlsToConvertOnLaunch: URL!
@@ -22,7 +22,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
-		mainWindowController = MainWindowController()
 		mainWindowController.showWindow(self)
 
 		hasFinishedLaunching = true

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -22,7 +22,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
-		mainWindowController = MainWindowController(windowNibName: NSNib.Name(rawValue: "MainWindowController"))
+		mainWindowController = MainWindowController()
 		mainWindowController.showWindow(self)
 
 		hasFinishedLaunching = true

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -8,44 +8,10 @@ extension NSColor {
 
 @NSApplicationMain
 final class AppDelegate: NSObject, NSApplicationDelegate {
-	@IBOutlet private weak var window: NSWindow!
-
-	private var progressObserver: NSKeyValueObservation?
-
-	lazy var circularProgress = with(CircularProgressView(frame: CGRect(widthHeight: 160))) {
-		$0.foreground = .appTheme
-		$0.strokeWidth = 2
-		$0.percentLabelLayer.setAutomaticContentsScale()
-		$0.percentLabelLayer.implicitAnimations = false
-		$0.layer?.backgroundColor = .clear
-		$0.isHidden = true
-		$0.centerInWindow(window)
-	}
-
-	lazy var videoDropView = with(VideoDropView()) {
-		$0.frame = window.contentView!.frame
-		$0.dropText = "Drop a Video to Convert to GIF"
-		$0.onComplete = { url in
-			self.convert(url.first!)
-		}
-	}
+	var mainWindowController: MainWindowController!
 
 	var hasFinishedLaunching = false
 	var urlsToConvertOnLaunch: URL!
-	var choosenDimensions: CGSize!
-	var choosenFrameRate: Int!
-
-	@objc dynamic var isRunning: Bool = false {
-		didSet {
-			if isRunning {
-				videoDropView.isHidden = true
-			} else {
-				videoDropView.fadeIn()
-			}
-
-			circularProgress.isHidden = !isRunning
-		}
-	}
 
 	func applicationWillFinishLaunching(_ notification: Notification) {
 		defaults.register(defaults: [
@@ -53,38 +19,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			"NSFullScreenMenuItemEverywhere": false,
 			"outputQuality": 1
 		])
-
-		with(window!) {
-			$0.titleVisibility = .hidden
-			$0.appearance = NSAppearance(named: .vibrantDark)
-			$0.tabbingMode = .disallowed
-			$0.titlebarAppearsTransparent = true
-			$0.isMovableByWindowBackground = true
-			$0.styleMask.remove([.resizable, .fullScreen])
-			$0.styleMask.insert(.fullSizeContentView)
-			$0.isRestorable = false
-			$0.setFrame(CGRect(width: 360, height: 240), display: true)
-			$0.center()
-		}
 	}
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
+		mainWindowController = MainWindowController(windowNibName: NSNib.Name(rawValue: "MainWindowController"))
+		mainWindowController.showWindow(self)
+
 		hasFinishedLaunching = true
 		NSApplication.shared.isAutomaticCustomizeTouchBarMenuItemEnabled = true
 
-		let view = window.contentView!
-		view.addSubview(circularProgress)
-		view.addSubview(videoDropView, positioned: .above, relativeTo: nil)
-
-		window.makeKeyAndOrderFront(nil) /// TODO: This is dirty, find a better way
-
 		if urlsToConvertOnLaunch != nil {
-			convert(urlsToConvertOnLaunch)
+			mainWindowController.convert(urlsToConvertOnLaunch)
 		}
 	}
 
 	func application(_ application: NSApplication, open urls: [URL]) {
-		guard !isRunning else {
+		guard !mainWindowController.isRunning else {
 			return
 		}
 
@@ -97,7 +47,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 		/// TODO: Simplify this. Make a function that calls the input when the app finished launching, or right away if it already has.
 		if hasFinishedLaunching {
-			convert(videoUrl)
+			mainWindowController.convert(videoUrl)
 		} else {
 			// This method is called before `applicationDidFinishLaunching`,
 			// so we buffer it up a video is "Open with" this app
@@ -107,92 +57,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
 		return true
-	}
-
-	// MARK: - First responders
-	@IBAction private func openDocument(_ sender: AnyObject) {
-		openPanel(sender)
-	}
-	// MARK: -
-
-	@objc
-	func openPanel(_ sender: AnyObject) {
-		let panel = NSOpenPanel()
-		panel.canChooseDirectories = false
-		panel.canCreateDirectories = false
-		panel.allowedFileTypes = System.supportedVideoTypes
-
-		panel.beginSheetModal(for: window) {
-			if $0 == .OK {
-				self.convert(panel.url!)
-			}
-		}
-	}
-
-	func convert(_ inputUrl: URL) {
-		// We already specify the UTIs we support, so this can only happen on invalid but supported files
-		guard inputUrl.isVideoDecodable else {
-			Misc.alert(title: "Video not supported", text: "The video you tried to convert could not be read.")
-			return
-		}
-
-		let panel = NSSavePanel()
-		panel.canCreateDirectories = true
-		panel.directoryURL = inputUrl.directoryURL
-		panel.nameFieldStringValue = inputUrl.changingFileExtension(to: "gif").filename
-		panel.prompt = "Convert"
-		panel.message = "Choose where to save the GIF"
-
-		let accessoryViewController = SavePanelAccessoryViewController()
-		accessoryViewController.inputUrl = inputUrl
-		panel.accessoryView = accessoryViewController.view
-
-		panel.beginSheetModal(for: window) {
-			if $0 == .OK {
-				self.startConversion(inputUrl: inputUrl, outputUrl: panel.url!)
-			}
-		}
-	}
-
-	func startConversion(inputUrl: URL, outputUrl: URL) {
-		guard !isRunning else {
-			return
-		}
-
-		isRunning = true
-
-		circularProgress.animated = false
-		circularProgress.progress = 0
-		circularProgress.animated = true
-
-		let progress = Progress(totalUnitCount: 1)
-
-		progress.performAsCurrent(withPendingUnitCount: 1) {
-			let conversion = Gifski.Conversion(
-				input: inputUrl,
-				output: outputUrl,
-				quality: defaults["outputQuality"] as! Double,
-				dimensions: self.choosenDimensions,
-				frameRate: self.choosenFrameRate
-			)
-			Gifski.run(conversion) { error in
-				DispatchQueue.main.async {
-					if let error = error {
-						fatalError(error.localizedDescription)
-					}
-					self.circularProgress.percentLabelLayer.string = "✔"
-					self.circularProgress.fadeOut(delay: 1) {
-						self.isRunning = false
-					}
-				}
-			}
-		}
-
-		progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
-			self.circularProgress.progress = CGFloat(progress.fractionCompleted)
-		}
-
-		DockProgress.progress = progress
-		DockProgress.style = .circle(radius: 55, color: .appTheme)
 	}
 }

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -8,7 +8,7 @@ extension NSColor {
 
 @NSApplicationMain
 final class AppDelegate: NSObject, NSApplicationDelegate {
-	var mainWindowController = MainWindowController()
+	let mainWindowController = MainWindowController()
 
 	var hasFinishedLaunching = false
 	var urlsToConvertOnLaunch: URL!

--- a/Gifski/Base.lproj/MainMenu.xib
+++ b/Gifski/Base.lproj/MainMenu.xib
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" customObjectInstantitationMethod="direct">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -12,11 +11,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Gifski" customModuleProvider="target">
-            <connections>
-                <outlet property="window" destination="QvC-M9-y7g" id="s3m-53-vJN"/>
-            </connections>
-        </customObject>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Gifski" customModuleProvider="target"/>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
             <items>
@@ -68,12 +63,7 @@
                         <items>
                             <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
-                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
-                                    <binding destination="Voe-Tx-rLC" name="enabled" keyPath="self.isRunning" id="zW7-dU-Zy9">
-                                        <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                        </dictionary>
-                                    </binding>
+                                    <action selector="open:" target="-1" id="E6Y-20-4aZ"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
@@ -135,16 +125,6 @@
             </items>
             <point key="canvasLocation" x="140" y="-217"/>
         </menu>
-        <window title="Gifski" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
-            <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
-                <autoresizingMask key="autoresizingMask"/>
-            </view>
-        </window>
         <userDefaultsController representsSharedInstance="YES" id="ZQM-Q3-CtF"/>
     </objects>
 </document>

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -34,10 +34,10 @@ final class Gifski {
 		let input: URL
 		let output: URL
 		let quality: Double
-		let dimensions: CGSize
+		let dimensions: CGSize?
 		let frameRate: Int?
 
-		init(input: URL, output: URL, quality: Double = 1, dimensions: CGSize = .zero, frameRate: Int? = nil) {
+		init(input: URL, output: URL, quality: Double = 1, dimensions: CGSize? = nil, frameRate: Int? = nil) {
 			self.input = input
 			self.output = output
 			self.quality = quality
@@ -48,8 +48,8 @@ final class Gifski {
 
 	static func run(_ conversion: Conversion, completionHandler: ((Error?) -> Void)?) {
 		let settings = GifskiSettings(
-			width: UInt32(conversion.dimensions.width),
-			height: UInt32(conversion.dimensions.height),
+			width: UInt32(conversion.dimensions?.width ?? 0),
+			height: UInt32(conversion.dimensions?.height ?? 0),
 			quality: UInt8(conversion.quality * 100),
 			once: false,
 			fast: false

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -7,7 +7,6 @@ extension NSNib.Name {
 }
 
 class MainWindowController: NSWindowController {
-
 	private var progressObserver: NSKeyValueObservation?
 
 	private lazy var circularProgress = with(CircularProgressView(frame: CGRect(widthHeight: 160))) {
@@ -169,5 +168,4 @@ class MainWindowController: NSWindowController {
 			return super.validateMenuItem(menuItem)
 		}
 	}
-
 }

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -2,6 +2,10 @@ import Cocoa
 import ProgressKit
 import DockProgress
 
+extension NSNib.Name {
+	static let mainWindowController = NSNib.Name("MainWindowController")
+}
+
 class MainWindowController: NSWindowController {
 
 	private var progressObserver: NSKeyValueObservation?
@@ -62,20 +66,8 @@ class MainWindowController: NSWindowController {
 		window!.makeKeyAndOrderFront(nil) /// TODO: This is dirty, find a better way
     }
 
-	// MARK: -
-
-	@objc
-	func open(_ sender: AnyObject) {
-		let panel = NSOpenPanel()
-		panel.canChooseDirectories = false
-		panel.canCreateDirectories = false
-		panel.allowedFileTypes = System.supportedVideoTypes
-
-		panel.beginSheetModal(for: window!) {
-			if $0 == .OK {
-				self.convert(panel.url!)
-			}
-		}
+	override var windowNibName: NSNib.Name? {
+		return .mainWindowController
 	}
 
 	func convert(_ inputUrl: URL) {
@@ -152,6 +144,22 @@ class MainWindowController: NSWindowController {
 
 		DockProgress.progress = progress
 		DockProgress.style = .circle(radius: 55, color: .appTheme)
+	}
+
+	// MARK: -
+
+	@objc
+	func open(_ sender: AnyObject) {
+		let panel = NSOpenPanel()
+		panel.canChooseDirectories = false
+		panel.canCreateDirectories = false
+		panel.allowedFileTypes = System.supportedVideoTypes
+
+		panel.beginSheetModal(for: window!) {
+			if $0 == .OK {
+				self.convert(panel.url!)
+			}
+		}
 	}
 
 	@objc

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -43,8 +43,8 @@ class MainWindowController: NSWindowController {
 		}
 	}
 
-    override func windowDidLoad() {
-        super.windowDidLoad()
+	override func windowDidLoad() {
+		super.windowDidLoad()
 
 		with(window!) {
 			$0.titleVisibility = .hidden
@@ -64,7 +64,7 @@ class MainWindowController: NSWindowController {
 		view.addSubview(videoDropView, positioned: .above, relativeTo: nil)
 
 		window!.makeKeyAndOrderFront(nil) /// TODO: This is dirty, find a better way
-    }
+	}
 
 	override var windowNibName: NSNib.Name? {
 		return .mainWindowController

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -1,0 +1,167 @@
+import Cocoa
+import ProgressKit
+import DockProgress
+
+class MainWindowController: NSWindowController {
+
+	private var progressObserver: NSKeyValueObservation?
+
+	lazy var circularProgress = with(CircularProgressView(frame: CGRect(widthHeight: 160))) {
+		$0.foreground = .appTheme
+		$0.strokeWidth = 2
+		$0.percentLabelLayer.setAutomaticContentsScale()
+		$0.percentLabelLayer.implicitAnimations = false
+		$0.layer?.backgroundColor = .clear
+		$0.isHidden = true
+		$0.centerInWindow(window)
+	}
+
+	lazy var videoDropView = with(VideoDropView()) {
+		$0.frame = window!.contentView!.frame
+		$0.dropText = "Drop a Video to Convert to GIF"
+		$0.onComplete = { url in
+			self.convert(url.first!)
+		}
+	}
+
+	var choosenDimensions: CGSize = .zero
+	var choosenFrameRate: Int?
+
+	var isRunning: Bool = false {
+		didSet {
+			if isRunning {
+				videoDropView.isHidden = true
+			} else {
+				videoDropView.fadeIn()
+			}
+
+			circularProgress.isHidden = !isRunning
+		}
+	}
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+
+		with(window!) {
+			$0.titleVisibility = .hidden
+			$0.appearance = NSAppearance(named: .vibrantDark)
+			$0.tabbingMode = .disallowed
+			$0.titlebarAppearsTransparent = true
+			$0.isMovableByWindowBackground = true
+			$0.styleMask.remove([.resizable, .fullScreen])
+			$0.styleMask.insert(.fullSizeContentView)
+			$0.isRestorable = false
+			$0.setFrame(CGRect(width: 360, height: 240), display: true)
+			$0.center()
+		}
+
+		let view = window!.contentView!
+		view.addSubview(circularProgress)
+		view.addSubview(videoDropView, positioned: .above, relativeTo: nil)
+
+		window!.makeKeyAndOrderFront(nil) /// TODO: This is dirty, find a better way
+    }
+
+	// MARK: -
+
+	@objc
+	func open(_ sender: AnyObject) {
+		let panel = NSOpenPanel()
+		panel.canChooseDirectories = false
+		panel.canCreateDirectories = false
+		panel.allowedFileTypes = System.supportedVideoTypes
+
+		panel.beginSheetModal(for: window!) {
+			if $0 == .OK {
+				self.convert(panel.url!)
+			}
+		}
+	}
+
+	func convert(_ inputUrl: URL) {
+		// We already specify the UTIs we support, so this can only happen on invalid but supported files
+		guard inputUrl.isVideoDecodable else {
+			Misc.alert(title: "Video not supported", text: "The video you tried to convert could not be read.")
+			return
+		}
+
+		let panel = NSSavePanel()
+		panel.canCreateDirectories = true
+		panel.directoryURL = inputUrl.directoryURL
+		panel.nameFieldStringValue = inputUrl.changingFileExtension(to: "gif").filename
+		panel.prompt = "Convert"
+		panel.message = "Choose where to save the GIF"
+
+		let accessoryViewController = SavePanelAccessoryViewController()
+		accessoryViewController.inputUrl = inputUrl
+
+		accessoryViewController.onDimensionChange = { dimension in
+			self.choosenDimensions = dimension
+		}
+
+		accessoryViewController.onFramerateChange = { frameRate in
+			self.choosenFrameRate = frameRate
+		}
+
+		panel.accessoryView = accessoryViewController.view
+
+		panel.beginSheetModal(for: window!) {
+			if $0 == .OK {
+				self.startConversion(inputUrl: inputUrl, outputUrl: panel.url!)
+			}
+		}
+	}
+
+	func startConversion(inputUrl: URL, outputUrl: URL) {
+		guard !isRunning else {
+			return
+		}
+
+		isRunning = true
+
+		circularProgress.animated = false
+		circularProgress.progress = 0
+		circularProgress.animated = true
+
+		let progress = Progress(totalUnitCount: 1)
+
+		progress.performAsCurrent(withPendingUnitCount: 1) {
+			let conversion = Gifski.Conversion(
+				input: inputUrl,
+				output: outputUrl,
+				quality: defaults["outputQuality"] as! Double,
+				dimensions: self.choosenDimensions,
+				frameRate: self.choosenFrameRate
+			)
+			Gifski.run(conversion) { error in
+				DispatchQueue.main.async {
+					if let error = error {
+						fatalError(error.localizedDescription)
+					}
+					self.circularProgress.percentLabelLayer.string = "✔"
+					self.circularProgress.fadeOut(delay: 1) {
+						self.isRunning = false
+					}
+				}
+			}
+		}
+
+		progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
+			self.circularProgress.progress = CGFloat(progress.fractionCompleted)
+		}
+
+		DockProgress.progress = progress
+		DockProgress.style = .circle(radius: 55, color: .appTheme)
+	}
+
+	@objc
+	override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+		switch menuItem.action {
+		case #selector(open(_:))?:
+			return !isRunning
+		default:
+			return super.validateMenuItem(menuItem)
+		}
+	}
+
+}

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -10,7 +10,7 @@ class MainWindowController: NSWindowController {
 
 	private var progressObserver: NSKeyValueObservation?
 
-	lazy var circularProgress = with(CircularProgressView(frame: CGRect(widthHeight: 160))) {
+	private lazy var circularProgress = with(CircularProgressView(frame: CGRect(widthHeight: 160))) {
 		$0.foreground = .appTheme
 		$0.strokeWidth = 2
 		$0.percentLabelLayer.setAutomaticContentsScale()
@@ -20,7 +20,7 @@ class MainWindowController: NSWindowController {
 		$0.centerInWindow(window)
 	}
 
-	lazy var videoDropView = with(VideoDropView()) {
+	private lazy var videoDropView = with(VideoDropView()) {
 		$0.frame = window!.contentView!.frame
 		$0.dropText = "Drop a Video to Convert to GIF"
 		$0.onComplete = { url in
@@ -28,8 +28,8 @@ class MainWindowController: NSWindowController {
 		}
 	}
 
-	var choosenDimensions: CGSize = .zero
-	var choosenFrameRate: Int?
+	private var choosenDimensions: CGSize = .zero
+	private var choosenFrameRate: Int?
 
 	var isRunning: Bool = false {
 		didSet {
@@ -44,8 +44,6 @@ class MainWindowController: NSWindowController {
 	}
 
 	override func windowDidLoad() {
-		super.windowDidLoad()
-
 		with(window!) {
 			$0.titleVisibility = .hidden
 			$0.appearance = NSAppearance(named: .vibrantDark)

--- a/Gifski/MainWindowController.xib
+++ b/Gifski/MainWindowController.xib
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="MainWindowController" customModule="Gifski" customModuleProvider="target">
+            <connections>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="335" y="390" width="480" height="360"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+        </window>
+    </objects>
+</document>

--- a/Gifski/SavePanelAccessoryViewController.swift
+++ b/Gifski/SavePanelAccessoryViewController.swift
@@ -8,6 +8,8 @@ final class SavePanelAccessoryViewController: NSViewController {
 	@IBOutlet private weak var frameRateLabel: NSTextField!
 	@IBOutlet private weak var qualitySlider: NSSlider!
 	var inputUrl: URL!
+	var onDimensionChange: ((CGSize) -> Void)?
+	var onFramerateChange: ((Int) -> Void)?
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -32,15 +34,13 @@ final class SavePanelAccessoryViewController: NSViewController {
 			currentDimensions = metadata.dimensions * self.scaleSlider.doubleValue
 			self.scaleLabel.stringValue = "\(Int(currentDimensions.width))×\(Int(currentDimensions.height))"
 			estimateFileSize()
-
-			/// TODO: Feels hacky to do it this way. Find a better way to pass the state.
-			self.appDelegate.choosenDimensions = currentDimensions
+			self.onDimensionChange?(currentDimensions)
 		}
 
 		frameRateSlider.onAction = { _ in
 			let frameRate = self.frameRateSlider.integerValue
 			self.frameRateLabel.stringValue = "\(frameRate)"
-			self.appDelegate.choosenFrameRate = frameRate
+			self.onFramerateChange?(frameRate)
 			estimateFileSize()
 		}
 


### PR DESCRIPTION
I thought the AppDelegate had to many responsibilities, so I moved a lot of the code into a WindowController.

I'm not sure what best practice is with handling menu item actions, but I changed the open menu items action, and enabled state to use the responder chain so that I could keep the logic in the Window controller..