### PR TITLE
Use `Result` type

### DIFF
--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -1203,14 +1203,14 @@ public enum Result<Success, Failure: Swift.Error> {
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new success value if this instance represents a success.
   public func map<NewSuccess>(
-    _ transform: (Success) -> NewSuccess
+	_ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
-    switch self {
-    case let .success(success):
-      return .success(transform(success))
-    case let .failure(failure):
-      return .failure(failure)
-    }
+	switch self {
+	case let .success(success):
+	  return .success(transform(success))
+	case let .failure(failure):
+	  return .failure(failure)
+	}
   }
 
   /// Returns a new result, mapping any failure value using the given
@@ -1240,14 +1240,14 @@ public enum Result<Success, Failure: Swift.Error> {
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new failure value if this instance represents a failure.
   public func mapError<NewFailure>(
-    _ transform: (Failure) -> NewFailure
+	_ transform: (Failure) -> NewFailure
   ) -> Result<Success, NewFailure> {
-    switch self {
-    case let .success(success):
-      return .success(success)
-    case let .failure(failure):
-      return .failure(transform(failure))
-    }
+	switch self {
+	case let .success(success):
+	  return .success(success)
+	case let .failure(failure):
+	  return .failure(transform(failure))
+	}
   }
 
   /// Returns a new result, mapping any success value using the given
@@ -1258,14 +1258,14 @@ public enum Result<Success, Failure: Swift.Error> {
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new failure value if this instance represents a failure.
   public func flatMap<NewSuccess>(
-    _ transform: (Success) -> Result<NewSuccess, Failure>
+	_ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
-    switch self {
-    case let .success(success):
-      return transform(success)
-    case let .failure(failure):
-      return .failure(failure)
-    }
+	switch self {
+	case let .success(success):
+	  return transform(success)
+	case let .failure(failure):
+	  return .failure(failure)
+	}
   }
 
   /// Returns a new result, mapping any failure value using the given
@@ -1276,14 +1276,14 @@ public enum Result<Success, Failure: Swift.Error> {
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.success`.
   public func flatMapError<NewFailure>(
-    _ transform: (Failure) -> Result<Success, NewFailure>
+	_ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
-    switch self {
-    case let .success(success):
-      return .success(success)
-    case let .failure(failure):
-      return transform(failure)
-    }
+	switch self {
+	case let .success(success):
+	  return .success(success)
+	case let .failure(failure):
+	  return transform(failure)
+	}
   }
 
   /// Returns the success value as a throwing expression.
@@ -1303,12 +1303,12 @@ public enum Result<Success, Failure: Swift.Error> {
   /// - Returns: The success value, if the instance represent a success.
   /// - Throws: The failure value, if the instance represents a failure.
   public func get() throws -> Success {
-    switch self {
-    case let .success(success):
-      return success
-    case let .failure(failure):
-      throw failure
-    }
+	switch self {
+	case let .success(success):
+	  return success
+	case let .failure(failure):
+	  throw failure
+	}
   }
 }
 
@@ -1321,7 +1321,7 @@ typealias CoreResult = Result
 
 
 public protocol CancellableError: Error {
-    /// Returns true if this Error represents a cancelled condition
+	/// Returns true if this Error represents a cancelled condition
 	var isCancelled: Bool { get }
 }
 
@@ -1330,24 +1330,24 @@ public struct CancellationError: CancellableError {
 }
 
 extension Error {
-    public var isCancelled: Bool {
-        do {
-            throw self
-        } catch let error as CancellableError {
-            return error.isCancelled
-        } catch URLError.cancelled {
-            return true
-        } catch CocoaError.userCancelled {
-            return true
-        } catch {
-        #if os(macOS) || os(iOS) || os(tvOS)
-            let pair = { ($0.domain, $0.code) }(error as NSError)
-            return pair == ("SKErrorDomain", 2)
-        #else
-            return false
-        #endif
-        }
-    }
+	public var isCancelled: Bool {
+		do {
+			throw self
+		} catch let error as CancellableError {
+			return error.isCancelled
+		} catch URLError.cancelled {
+			return true
+		} catch CocoaError.userCancelled {
+			return true
+		} catch {
+		#if os(macOS) || os(iOS) || os(tvOS)
+			let pair = { ($0.domain, $0.code) }(error as NSError)
+			return pair == ("SKErrorDomain", 2)
+		#else
+			return false
+		#endif
+		}
+	}
 }
 
 extension Result {
@@ -1363,12 +1363,12 @@ extension Result {
 	}
 	```
 	*/
-    public var isCancelled: Bool {
-        do {
-            _ = try get()
+	public var isCancelled: Bool {
+		do {
+			_ = try get()
 			return false
-        } catch {
-            return error.isCancelled
+		} catch {
+			return error.isCancelled
 		}
-    }
+	}
 }

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2,6 +2,10 @@ import Cocoa
 import AVFoundation
 
 
+/// YOLO
+extension String: Error {}
+
+
 /**
 Convenience function for initializing an object and modifying its properties
 
@@ -295,9 +299,63 @@ extension NSAlert {
 
 
 extension AVAssetImageGenerator {
-	func generateCGImagesAsynchronously(forTimePoints timePoints: [CMTime], completionHandler: @escaping AVAssetImageGeneratorCompletionHandler) {
+	struct CompletionHandlerResult {
+		let image: CGImage?
+		let requestedTime: CMTime
+		let actualTime: CMTime
+		let completedCount: Int
+		let totalCount: Int
+		let isCancelled: Bool
+		let isFinished: Bool
+	}
+
+	/// TODO: Remove this when using Swift 5
+	enum Error: Swift.Error {}
+
+	func generateCGImagesAsynchronously(
+		forTimePoints timePoints: [CMTime],
+		completionHandler: @escaping (CoreResult<CompletionHandlerResult, Error>) -> Void
+	) {
 		let times = timePoints.map { NSValue(time: $0) }
-		generateCGImagesAsynchronously(forTimes: times, completionHandler: completionHandler)
+		let totalCount = times.count
+		var completedCount = 0
+
+		generateCGImagesAsynchronously(forTimes: times) { requestedTime, image, actualTime, result, error in
+			switch result {
+			case .succeeded:
+				completedCount += 1
+
+				completionHandler(
+					.success(
+						CompletionHandlerResult(
+							image: image,
+							requestedTime: requestedTime,
+							actualTime: actualTime,
+							completedCount: completedCount,
+							totalCount: totalCount,
+							isCancelled: false,
+							isFinished: completedCount == totalCount
+						)
+					)
+				)
+			case .failed:
+				completionHandler(.failure(error! as! Error))
+			case .cancelled:
+				completionHandler(
+					.success(
+						CompletionHandlerResult(
+							image: image,
+							requestedTime: requestedTime,
+							actualTime: actualTime,
+							completedCount: completedCount,
+							totalCount: totalCount,
+							isCancelled: true,
+							isFinished: completedCount == totalCount
+						)
+					)
+				)
+			}
+		}
 	}
 }
 
@@ -1117,3 +1175,152 @@ extension CGRect {
 		)
 	}
 }
+
+
+/// Polyfill for Swift 5
+/// https://github.com/moiseev/swift/blob/47740c012943020aa89df93129b4fc2f33618c00/stdlib/public/core/Result.swift
+/// TODO: Remove when using Swift 5
+///
+/// A value that represents either a success or a failure, including an
+/// associated value in each case.
+public enum Result<Success, Failure: Swift.Error> {
+  /// A success, storing a `Success` value.
+  case success(Success)
+
+  /// A failure, storing a `Failure` value.
+  case failure(Failure)
+
+  /// Returns a new result, mapping any success value using the given
+  /// transformation.
+  ///
+  /// Use this method when you need to transform the value of a `Result`
+  /// instance when it represents a success. The following example transforms
+  /// the integer success value of a result into a string:
+  ///
+  ///     func getNextInteger() -> Result<Int, Error> { ... }
+  ///
+  ///     let integerResult = getNextInteger()
+  ///     // integerResult == .success(5)
+  ///     let stringResult = integerResult.map({ String($0) })
+  ///     // stringResult == .success("5")
+  ///
+  /// - Parameter transform: A closure that takes the success value of this
+  ///   instance.
+  /// - Returns: A `Result` instance with the result of evaluating `transform`
+  ///   as the new success value if this instance represents a success.
+  public func map<NewSuccess>(
+    _ transform: (Success) -> NewSuccess
+  ) -> Result<NewSuccess, Failure> {
+    switch self {
+    case let .success(success):
+      return .success(transform(success))
+    case let .failure(failure):
+      return .failure(failure)
+    }
+  }
+
+  /// Returns a new result, mapping any failure value using the given
+  /// transformation.
+  ///
+  /// Use this method when you need to transform the value of a `Result`
+  /// instance when it represents a failure. The following example transforms
+  /// the error value of a result by wrapping it in a custom `Error` type:
+  ///
+  ///     struct DatedError: Error {
+  ///         var error: Error
+  ///         var date: Date
+  ///
+  ///         init(_ error: Error) {
+  ///             self.error = error
+  ///             self.date = Date()
+  ///         }
+  ///     }
+  ///
+  ///     let result: Result<Int, Error> = ...
+  ///     // result == .failure(<error value>)
+  ///     let resultWithDatedError = result.mapError({ e in DatedError(e) })
+  ///     // result == .failure(DatedError(error: <error value>, date: <date>))
+  ///
+  /// - Parameter transform: A closure that takes the failure value of the
+  ///   instance.
+  /// - Returns: A `Result` instance with the result of evaluating `transform`
+  ///   as the new failure value if this instance represents a failure.
+  public func mapError<NewFailure>(
+    _ transform: (Failure) -> NewFailure
+  ) -> Result<Success, NewFailure> {
+    switch self {
+    case let .success(success):
+      return .success(success)
+    case let .failure(failure):
+      return .failure(transform(failure))
+    }
+  }
+
+  /// Returns a new result, mapping any success value using the given
+  /// transformation and unwrapping the produced result.
+  ///
+  /// - Parameter transform: A closure that takes the success value of the
+  ///   instance.
+  /// - Returns: A `Result` instance with the result of evaluating `transform`
+  ///   as the new failure value if this instance represents a failure.
+  public func flatMap<NewSuccess>(
+    _ transform: (Success) -> Result<NewSuccess, Failure>
+  ) -> Result<NewSuccess, Failure> {
+    switch self {
+    case let .success(success):
+      return transform(success)
+    case let .failure(failure):
+      return .failure(failure)
+    }
+  }
+
+  /// Returns a new result, mapping any failure value using the given
+  /// transformation and unwrapping the produced result.
+  ///
+  /// - Parameter transform: A closure that takes the failure value of the
+  ///   instance.
+  /// - Returns: A `Result` instance, either from the closure or the previous
+  ///   `.success`.
+  public func flatMapError<NewFailure>(
+    _ transform: (Failure) -> Result<Success, NewFailure>
+  ) -> Result<Success, NewFailure> {
+    switch self {
+    case let .success(success):
+      return .success(success)
+    case let .failure(failure):
+      return transform(failure)
+    }
+  }
+
+  /// Returns the success value as a throwing expression.
+  ///
+  /// Use this method to retrieve the value of this result if it represents a
+  /// success, or to catch the value if it represents a failure.
+  ///
+  ///     let integerResult: Result<Int, Error> = .success(5)
+  ///     do {
+  ///         let value = try integerResult.get()
+  ///         print("The value is \(value).")
+  ///     } catch error {
+  ///         print("Error retrieving the value: \(error)")
+  ///     }
+  ///     // Prints "The value is 5."
+  ///
+  /// - Returns: The success value, if the instance represent a success.
+  /// - Throws: The failure value, if the instance represents a failure.
+  public func get() throws -> Success {
+    switch self {
+    case let .success(success):
+      return success
+    case let .failure(failure):
+      throw failure
+    }
+  }
+}
+
+extension Result: Equatable where Success: Equatable, Failure: Equatable {}
+extension Result: Hashable where Success: Hashable, Failure: Hashable {}
+
+// To be able to use it in places that already have a local result
+// TODO: Remove this when using Swift 5
+typealias CoreResult = Result


### PR DESCRIPTION
This makes `generateCGImagesAsynchronously` method use a `Result` type. I was not sure whether or not to model the "cancelled" state as success or error.