### PR TITLE
Tweak custom button color generator setter

### DIFF
--- a/Gifski/CustomButton.swift
+++ b/Gifski/CustomButton.swift
@@ -225,20 +225,20 @@ open class CustomButton: NSButton {
 		needsDisplay = true
 	}
 
-	public typealias ColorGenerationHandler = () -> NSColor
+	public typealias ColorGenerator = () -> NSColor
 
-	private var colorGenerators = [KeyPath<CustomButton, NSColor>: ColorGenerationHandler]()
+	private var colorGenerators = [KeyPath<CustomButton, NSColor>: ColorGenerator]()
 
-	/// Provides a way to re-generate a color on layer update.
-	/// Especially useful for applying alpha values to accent color changes that can be triggered outside of the app.
+	/// Gets or sets the color generation closure for the provided key path.
 	///
-	/// Note: should not be used for returning regular colors.
-	///
-	/// - Parameters:
-	///   - keyPath: The key path to the color to generate.
-	///   - handler: The handler that returns the proper `NSColor`.
-	public func setColorGenerator(for keyPath: KeyPath<CustomButton, NSColor>, _ handler: ColorGenerationHandler?) {
-		colorGenerators[keyPath] = handler
+	/// - Parameter keyPath: The key path that specifies the color related property.
+	subscript (colorGenerator keyPath: KeyPath<CustomButton, NSColor>) -> ColorGenerator? {
+		get {
+			return colorGenerators[keyPath]
+		}
+		set {
+			colorGenerators[keyPath] = newValue
+		}
 	}
 
 	private func color(for keyPath: KeyPath<CustomButton, NSColor>) -> NSColor {

--- a/Gifski/CustomButton.swift
+++ b/Gifski/CustomButton.swift
@@ -237,12 +237,8 @@ open class CustomButton: NSButton {
 	/// - Parameters:
 	///   - keyPath: The key path to the color to generate.
 	///   - handler: The handler that returns the proper `NSColor`.
-	public func setColorGenerator(for keyPath: KeyPath<CustomButton, NSColor>, handler: @escaping ColorGenerationHandler) {
+	public func setColorGenerator(for keyPath: KeyPath<CustomButton, NSColor>, _ handler: ColorGenerationHandler?) {
 		colorGenerators[keyPath] = handler
-	}
-
-	public func removeColorGenerator(for keyPath: KeyPath<CustomButton, NSColor>) {
-		colorGenerators[keyPath] = nil
 	}
 
 	private func color(for keyPath: KeyPath<CustomButton, NSColor>) -> NSColor {

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -28,7 +28,7 @@ final class MainWindowController: NSWindowController {
 
 	private lazy var cancelButton = with(CustomButton.circularButton(title: "╳", size: 130)) {
 		$0.textColor = .appTheme
-		$0.setColorGenerator(for: \.backgroundColor) {
+		$0[colorGenerator: \.backgroundColor] = {
 			NSColor.appTheme.with(alpha: 0.1)
 		}
 		$0.borderWidth = 0


### PR DESCRIPTION
See https://github.com/sindresorhus/gifski-app/pull/50#pullrequestreview-194865256

Allows for `$0.setColorGenerator(for: \.backgroundColor, nil)` to be used, making the `removeGenerator(for keyPath:)` method redundant.