### PR TITLE
Fix off-by-one error and ensure Gifski completion handler is only called once

### DIFF
--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -62,9 +62,6 @@ final class MainWindowController: NSWindowController {
 						self.videoDropView.isHidden = false
 						self.videoDropView.fadeInVideoDropLabel()
 					}
-
-					// Workaround for https://github.com/sindresorhus/gifski-app/issues/46
-					self.progress?.completedUnitCount = 0
 				}
 			} else {
 				circularProgress.isHidden = false

--- a/Gifski/Vendor/DockProgress.swift
+++ b/Gifski/Vendor/DockProgress.swift
@@ -14,9 +14,8 @@ public final class DockProgress {
 	public static var progress: Progress? {
 		didSet {
 			if let progress = progress {
-				progressObserver = progress.observe(\.fractionCompleted) { object, _ in
-					print("progress", object.fractionCompleted, object.isFinished, object.completedUnitCount, object.totalUnitCount)
-					progressValue = object.fractionCompleted
+				progressObserver = progress.observe(\.fractionCompleted) { sender, _ in
+					progressValue = sender.fractionCompleted
 				}
 			}
 		}

--- a/Gifski/Vendor/DockProgress.swift
+++ b/Gifski/Vendor/DockProgress.swift
@@ -15,6 +15,7 @@ public final class DockProgress {
 		didSet {
 			if let progress = progress {
 				progressObserver = progress.observe(\.fractionCompleted) { object, _ in
+					print("progress", object.fractionCompleted, object.isFinished, object.completedUnitCount, object.totalUnitCount)
 					progressValue = object.fractionCompleted
 				}
 			}

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -1373,3 +1373,89 @@ extension Result {
 		}
 	}
 }
+
+
+final class Once {
+	private var lock = os_unfair_lock()
+	private var hasRun = false
+	private var value: Any?
+
+	/**
+	Executes the given closure only once. (Thread-safe)
+
+	Returns the value that the called closure returns the first (and only) time it's called.
+
+	```
+	final class Foo {
+		private let once = Once()
+
+		func bar() {
+			once.run {
+				print("Called only once")
+			}
+		}
+	}
+
+	let foo = Foo()
+	foo.bar()
+	foo.bar()
+	```
+
+	```
+	func process(_ text: String) -> String {
+		return text
+	}
+
+	let a = once.run {
+		process("a")
+	}
+
+	let b = once.run {
+		process("b")
+	}
+
+	print(a, b)
+	//=> "a a"
+	```
+	*/
+	func run<T>(_ closure: () throws -> T) rethrows -> T {
+		os_unfair_lock_lock(&lock)
+		defer {
+			os_unfair_lock_unlock(&lock)
+		}
+
+		guard !hasRun else {
+			return value as! T
+		}
+
+		hasRun = true
+
+		let returnValue = try closure()
+		value = returnValue
+		return returnValue
+	}
+
+	// TODO: Make it support `rethrows` so that if the input `function` is `throws` then the wrapped function becomes throwing too.
+	// TODO: Support any number of arguments when Swift supports variadics.
+	// Wraps a single-argument function.
+	func wrap<T, U>(_ function: @escaping ((T) -> U)) -> ((T) -> U) {
+		return { parameter in
+			self.run {
+				function(parameter)
+			}
+		}
+	}
+
+	// Wraps an optional single-argument function.
+	func wrap<T, U>(_ function: ((T) -> U)?) -> ((T) -> U)? {
+		guard let function = function else {
+			return nil
+		}
+
+		return { parameter in
+			self.run {
+				function(parameter)
+			}
+		}
+	}
+}


### PR DESCRIPTION
I introduced an off-by-one error in 8a764ad695b097cf99356735a9653dd11f0ab1ef. It was only noticeable when trying to convert the video in https://github.com/sindresorhus/gifski-app/issues/46, which is why I didn't discover it when I did the change.

We also had the problem that the `completionHandler` could be called multiple times because we have it in the `generateCGImagesAsynchronously` closure which is called for each finished image or cancellation.

Since there's no good way that I know of to enforce a function to only be called once, I have created my own little clever thing.