### PR TITLE
Improve debug info included in errors

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -61,16 +61,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func application(_ application: NSApplication, willPresentError error: Error) -> Error {
-		#if !DEBUG
-			Crashlytics.sharedInstance().recordError(
-				// This forces Crashlytics to actually provide some useful info for Swift errors
-				error as NSError,
-				withAdditionalUserInfo: [
-					"type": "\(type(of: error)).\(error)",
-					"localizedDescription": error.localizedDescription
-				])
-		#endif
-
+		Crashlytics.sharedInstance().recordErrorBetter(error)
 		return error
 	}
 }

--- a/Gifski/Gifski.swift
+++ b/Gifski/Gifski.swift
@@ -119,7 +119,9 @@ final class Gifski {
 						let data = image.dataProvider?.data,
 						let buffer = CFDataGetBytePtr(data)
 					else {
-						completionHandlerOnce(.generateFrameFailed("Could not get byte pointer of image data provider"))
+						completionHandlerOnce(.generateFrameFailed(
+							NSError.appError(message: "Could not get byte pointer of image data provider")
+						))
 						return
 					}
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -105,6 +105,8 @@ final class MainWindowController: NSWindowController {
 	func convert(_ inputUrl: URL) {
 		let asset = AVURLAsset(url: inputUrl)
 
+		print(asset.debugInfo)
+
 		guard asset.videoCodec != "rle" else {
 			NSAlert.showModal(
 				for: window,

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -105,8 +105,6 @@ final class MainWindowController: NSWindowController {
 	func convert(_ inputUrl: URL) {
 		let asset = AVURLAsset(url: inputUrl)
 
-		print(asset.debugInfo)
-
 		guard asset.videoCodec != "rle" else {
 			NSAlert.showModal(
 				for: window,

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -416,6 +416,8 @@ extension FixedWidthInteger {
 
 extension String.StringInterpolation {
 	/**
+	Interpolate the value by unwrapping it, and if `nil`, use the given default string.
+
 	```
 	// This doesn't work as you can only use nil coalescing in interpolation with the same type as the optional
 	"foo \(optionalDouble ?? "none")
@@ -429,6 +431,25 @@ extension String.StringInterpolation {
 			appendInterpolation(value)
 		} else {
 			appendLiteral(defaultValue)
+		}
+	}
+
+	/**
+	Interpolate the value by unwrapping it, and if `nil`, use `"nil"`.
+
+	```
+	// This doesn't work as you can only use nil coalescing in interpolation with the same type as the optional
+	"foo \(optionalDouble ?? "nil")
+
+	// Now you can do this
+	"foo \(describing: optionalDouble)
+	```
+	*/
+	public mutating func appendInterpolation(describing value: Any?) {
+		if let value = value {
+			appendInterpolation(value)
+		} else {
+			appendLiteral("nil")
 		}
 	}
 }
@@ -658,12 +679,12 @@ extension AVAsset {
 			"""
 
 			## AVAsset debug info ##
-			Extension: \((self as? AVURLAsset)?.url.fileExtension ?? "nil")
-			Video codec: \(videoCodec, default: "nil")
-			Audio codec: \(audioCodec, default: "nil")
-			Duration: \(durationFormatter.string(from: duration.seconds), default: "nil")
-			Dimension: \(dimensions?.formatted, default: "nil")
-			Frame rate: \(frameRate?.rounded(toDecimalPlaces: 2).formatted, default: "nil")
+			Extension: \(describing: (self as? AVURLAsset)?.url.fileExtension)
+			Video codec: \(describing: videoCodec)
+			Audio codec: \(describing: audioCodec)
+			Duration: \(describing: durationFormatter.string(from: duration.seconds))
+			Dimension: \(describing: dimensions?.formatted)
+			Frame rate: \(describing: frameRate?.rounded(toDecimalPlaces: 2).formatted)
 			File size: \(fileSizeFormatted)
 			Is readable: \(isReadable)
 			Is playable: \(isPlayable)
@@ -678,10 +699,10 @@ extension AVAsset {
 				Track #\(track.trackID)
 				----
 				Type: \(String(reflecting: track.mediaType))
-				Codec: \(track.codec, default: "nil")
-				Duration: \(durationFormatter.string(from: track.timeRange.duration.seconds), default: "<None>")
-				Dimensions: \(track.dimensions?.formatted, default: "nil")
-				Frame rate: \(track.frameRate?.rounded(toDecimalPlaces: 2).formatted, default: "nil")
+				Codec: \(describing: track.codec)
+				Duration: \(describing: durationFormatter.string(from: track.timeRange.duration.seconds))
+				Dimensions: \(describing: track.dimensions?.formatted)
+				Frame rate: \(describing: track.frameRate?.rounded(toDecimalPlaces: 2).formatted)
 				Is playable: \(track.isPlayable)
 				Is decodable: \(track.isDecodable)
 				----

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <div align="center">
-	<img src="Stuff/AppIcon-readme.png" width="256" height="256">
+	<img src="Stuff/AppIcon-readme.png" width="200" height="200">
 	<h1>Gifski</h1>
 	<p>
 		<b>Convert videos to high-quality GIFs on your Mac</b>
@@ -10,6 +10,8 @@
 </div>
 
 This is a macOS app for the [`gifski` encoder](https://gif.ski), which converts videos to GIF animations using [`pngquant`](https://pngquant.org)'s fancy features for efficient cross-frame palettes and temporal dithering. It produces animated GIFs that use thousands of colors per frame.
+
+Gifski supports all the video formats that macOS supports (`.mp4` or `.mov` with H264, HEVC, ProRes, etc). The [QuickTime Animation format](https://en.wikipedia.org/wiki/QuickTime_Animation) is not supported. Use [ProRes 4444 XQ](https://en.wikipedia.org/wiki/Apple_ProRes) instead. It's more efficient, more widely supported, and like QuickTime Animation, it also supports alpha channel.
 
 **[Blog post](https://blog.sindresorhus.com/gifski-972692460aa5)** &nbsp;&nbsp; **[Product Hunt](https://www.producthunt.com/posts/gifski)**
 


### PR DESCRIPTION
With Gifski 1.5.1 we are officially crash-free 🎉 I am, however, seeing many users trying to use unsupported video codecs. I'm curious what they're trying to use and why it's not working. This PR will let me get better insight into that.

This also adds a better warning for when people tries to convert a video file with the QuickTime Animation format, which is supported by QuickTime Player, but not by AVFoundation. Gifski now shows a friendly error message instead.


Example output from the debug info (QuickTime Animation format):

```
## AVAsset debug info ##
Extension: mov
Video codec: rle
Audio codec: nil
Duration: 10s
Dimension: 500×500
Frame rate: 12
File size: 15.4 MB
Is readable: true
Is playable: false
Is exportable: true
Has protected content: false

Track #1
----
Type: Video
Codec: rle
Duration: 10s
Dimensions: 500×500
Frame rate: 12
Is playable: false
Is decodable: false
----

Track #2
----
Type: Time code
Codec: tmcd
Duration: 10s
Dimensions: nil
Frame rate: 0.1
Is playable: true
Is decodable: true
----
```

Anything other useful info I should include?

There's a lot of code here. I don't expect any of you to review it all. I'm mostly interested in feedback on the debug output/structure and what to include. Also the wording in the error messages.