### PR TITLE
Add Quick Look shortcut to the conversion completed view

### DIFF
--- a/Gifski/Base.lproj/MainMenu.xib
+++ b/Gifski/Base.lproj/MainMenu.xib
@@ -70,7 +70,7 @@
                             <menuItem title="Quick Look" keyEquivalent=" " id="Wfh-bM-KvX">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="quickLook:" target="-1" id="Zr4-ny-Pim"/>
+                                    <action selector="quickLook:" target="-1" id="IQy-U1-llq"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>

--- a/Gifski/Base.lproj/MainMenu.xib
+++ b/Gifski/Base.lproj/MainMenu.xib
@@ -66,6 +66,12 @@
                                     <action selector="open:" target="-1" id="E6Y-20-4aZ"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Quick Look..." keyEquivalent=" " id="Wfh-bM-KvX">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="quickLook:" target="-1" id="h7S-AO-RZK"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
                             <menuItem title="Close" keyEquivalent="w" id="3u8-9s-Y0B">
                                 <connections>

--- a/Gifski/Base.lproj/MainMenu.xib
+++ b/Gifski/Base.lproj/MainMenu.xib
@@ -66,7 +66,8 @@
                                     <action selector="open:" target="-1" id="E6Y-20-4aZ"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Quick Look..." keyEquivalent=" " id="Wfh-bM-KvX">
+                            <menuItem isSeparatorItem="YES" id="TB9-2E-bka"/>
+                            <menuItem title="Quick Look" keyEquivalent=" " id="Wfh-bM-KvX">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="quickLook:" target="-1" id="h7S-AO-RZK"/>

--- a/Gifski/Base.lproj/MainMenu.xib
+++ b/Gifski/Base.lproj/MainMenu.xib
@@ -70,7 +70,7 @@
                             <menuItem title="Quick Look" keyEquivalent=" " id="Wfh-bM-KvX">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="quickLook:" target="-1" id="h7S-AO-RZK"/>
+                                    <action selector="quickLook:" target="-1" id="Zr4-ny-Pim"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>

--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -29,6 +29,10 @@ final class ConversionCompletedView: SSView {
 		$0.spacing = 20
 	}
 
+	private var isConversionCompleted: Bool {
+		return isHidden == false && fileUrl != nil
+	}
+
 	private func createButton(title: String) -> CustomButton {
 		return with(CustomButton()) {
 			$0.title = title
@@ -68,6 +72,8 @@ final class ConversionCompletedView: SSView {
 	}
 
 	func show() {
+		// We need to manually make self as the first responder, but when the view is hidden it is auto-removed
+		window?.makeFirstResponder(self)
 		fadeIn()
 	}
 
@@ -131,6 +137,10 @@ final class ConversionCompletedView: SSView {
 }
 
 extension ConversionCompletedView: QLPreviewPanelDataSource {
+	@IBAction private func quickLook(_ sender: Any) {
+		quickLookPreviewItems(nil)
+	}
+
 	override func quickLook(with event: NSEvent) {
 		quickLookPreviewItems(nil)
 	}
@@ -173,5 +183,16 @@ extension ConversionCompletedView: QLPreviewPanelDelegate {
 
 	func previewPanel(_ panel: QLPreviewPanel!, transitionImageFor item: QLPreviewItem!, contentRect: UnsafeMutablePointer<CGRect>!) -> Any! {
 		return draggableFile.image
+	}
+}
+
+extension ConversionCompletedView: NSMenuItemValidation {
+	func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+		switch menuItem.action {
+		case #selector(quickLook(_:))?:
+			return isConversionCompleted
+		default:
+			return true
+		}
 	}
 }

--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -74,6 +74,7 @@ final class ConversionCompletedView: SSView {
 	func show() {
 		// We need to manually make self as the first responder, but when the view is hidden it is auto-removed
 		window?.makeFirstResponder(self)
+
 		fadeIn()
 	}
 

--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -168,14 +168,7 @@ extension ConversionCompletedView: QLPreviewPanelDataSource {
 
 extension ConversionCompletedView: QLPreviewPanelDelegate {
 	func previewPanel(_ panel: QLPreviewPanel!, sourceFrameOnScreenFor item: QLPreviewItem!) -> CGRect {
-		guard let imageRect = draggableFile.subviews.first?.frame, let window = window else {
-			return .zero
-		}
-
-		let windowFrame = draggableFile.convert(imageRect, to: nil)
-		let screenFrame = window.convertToScreen(windowFrame)
-		
-		return screenFrame
+		return draggableFile.imageView?.boundsInScreenCoordinates ?? .zero
 	}
 
 	func previewPanel(_ panel: QLPreviewPanel!, transitionImageFor item: QLPreviewItem!, contentRect: UnsafeMutablePointer<CGRect>!) -> Any! {

--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -71,18 +71,6 @@ final class ConversionCompletedView: SSView {
 		fadeIn()
 	}
 
-	override func quickLook(with event: NSEvent) {
-		quickLookPreviewItems(nil)
-	}
-
-	override func quickLookPreviewItems(_ sender: Any?) {
-		guard let panel = QLPreviewPanel.shared() else {
-			return
-		}
-
-		panel.toggle()
-	}
-
 	override func didAppear() {
 		translatesAutoresizingMaskIntoConstraints = false
 
@@ -143,6 +131,18 @@ final class ConversionCompletedView: SSView {
 }
 
 extension ConversionCompletedView: QLPreviewPanelDataSource {
+	override func quickLook(with event: NSEvent) {
+		quickLookPreviewItems(nil)
+	}
+
+	override func quickLookPreviewItems(_ sender: Any?) {
+		guard let panel = QLPreviewPanel.shared() else {
+			return
+		}
+
+		panel.toggle()
+	}
+
 	override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
 		return true
 	}

--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -80,11 +80,7 @@ final class ConversionCompletedView: SSView {
 			return
 		}
 
-		if panel.isVisible {
-			panel.orderOut(nil)
-		} else {
-			panel.makeKeyAndOrderFront(nil)
-		}
+		panel.toggle()
 	}
 
 	override func didAppear() {

--- a/Gifski/ConversionCompletedView.swift
+++ b/Gifski/ConversionCompletedView.swift
@@ -167,7 +167,7 @@ extension ConversionCompletedView: QLPreviewPanelDataSource {
 }
 
 extension ConversionCompletedView: QLPreviewPanelDelegate {
-	func previewPanel(_ panel: QLPreviewPanel!, sourceFrameOnScreenFor item: QLPreviewItem!) -> NSRect {
+	func previewPanel(_ panel: QLPreviewPanel!, sourceFrameOnScreenFor item: QLPreviewItem!) -> CGRect {
 		guard let imageRect = draggableFile.subviews.first?.frame, let window = window else {
 			return .zero
 		}
@@ -178,7 +178,7 @@ extension ConversionCompletedView: QLPreviewPanelDelegate {
 		return screenFrame
 	}
 
-	func previewPanel(_ panel: QLPreviewPanel!, transitionImageFor item: QLPreviewItem!, contentRect: UnsafeMutablePointer<NSRect>!) -> Any! {
+	func previewPanel(_ panel: QLPreviewPanel!, transitionImageFor item: QLPreviewItem!, contentRect: UnsafeMutablePointer<CGRect>!) -> Any! {
 		return draggableFile.image
 	}
 }

--- a/Gifski/DraggableFile.swift
+++ b/Gifski/DraggableFile.swift
@@ -27,6 +27,10 @@ final class DraggableFile: NSImageView {
 		}
 	}
 
+	var imageView: NSView? {
+		return subviews.first
+	}
+
 	override init(frame: CGRect) {
 		super.init(frame: frame)
 

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -2,7 +2,6 @@ import Cocoa
 import AVFoundation
 import StoreKit
 import Crashlytics
-import Quartz
 
 final class MainWindowController: NSWindowController {
 	private lazy var circularProgress = with(CircularProgress(size: 160)) {
@@ -307,15 +306,11 @@ final class MainWindowController: NSWindowController {
 	}
 
 	@IBAction private func quickLook(_ sender: Any) {
-		guard let panel = QLPreviewPanel.shared() else {
-			return
-		}
-
-		if panel.isVisible {
-			panel.orderOut(nil)
-		} else {
-			panel.makeKeyAndOrderFront(nil)
-		}
+		// Kind of a hack to get our conversion view to be the next responder to answer
+		// for QLPreviewPanel methods. Can we do it better?
+		nextResponder = conversionCompletedView
+		conversionCompletedView.quickLookPreviewItems(nil)
+		nextResponder = nil
 	}
 
 	private func setupTimeRemainingLabel() {
@@ -342,33 +337,5 @@ extension MainWindowController: NSMenuItemValidation {
 		default:
 			return true
 		}
-	}
-}
-
-extension MainWindowController: QLPreviewPanelDataSource {
-	override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
-		return true
-	}
-
-	override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
-		guard let panel = QLPreviewPanel.shared() else {
-			return
-		}
-
-		panel.dataSource = self
-		panel.makeKeyAndOrderFront(self)
-	}
-
-	override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
-		// For some reason if we do not override this func, the app will crash
-		// when hiding the panel
-	}
-
-	func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
-		return 1
-	}
-
-	func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
-		return outUrl as NSURL
 	}
 }

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -62,7 +62,7 @@ final class MainWindowController: NSWindowController {
 		}
 	}
 
-	var conversionCompleted: Bool {
+	var isConversionCompleted: Bool {
 		return conversionCompletedView.isHidden == false && outUrl != nil
 	}
 
@@ -338,7 +338,7 @@ extension MainWindowController: NSMenuItemValidation {
 		case #selector(open)?:
 			return !isRunning
 		case #selector(quickLook(_:))?:
-			return conversionCompleted
+			return isConversionCompleted
 		default:
 			return true
 		}

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -61,10 +61,6 @@ final class MainWindowController: NSWindowController {
 		}
 	}
 
-	var isConversionCompleted: Bool {
-		return conversionCompletedView.isHidden == false && outUrl != nil
-	}
-
 	convenience init() {
 		let window = NSWindow.centeredWindow(size: CGSize(width: 360, height: 240))
 		self.init(window: window)
@@ -305,14 +301,6 @@ final class MainWindowController: NSWindowController {
 		}
 	}
 
-	@IBAction private func quickLook(_ sender: Any) {
-		// Kind of a hack to get our conversion view to be the next responder to answer
-		// for QLPreviewPanel methods. Can we do it better?
-		nextResponder = conversionCompletedView
-		conversionCompletedView.quickLookPreviewItems(nil)
-		nextResponder = nil
-	}
-
 	private func setupTimeRemainingLabel() {
 		guard let view = view else {
 			return
@@ -332,8 +320,6 @@ extension MainWindowController: NSMenuItemValidation {
 		switch menuItem.action {
 		case #selector(open)?:
 			return !isRunning
-		case #selector(quickLook(_:))?:
-			return isConversionCompleted
 		default:
 			return true
 		}

--- a/Gifski/MainWindowController.swift
+++ b/Gifski/MainWindowController.swift
@@ -63,7 +63,7 @@ final class MainWindowController: NSWindowController {
 	}
 
 	var conversionCompleted: Bool {
-		return conversionCompletedView.isHidden == false && self.outUrl != nil
+		return conversionCompletedView.isHidden == false && outUrl != nil
 	}
 
 	convenience init() {

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -2123,3 +2123,10 @@ extension QLPreviewPanel {
 		}
 	}
 }
+
+extension NSView {
+	/// Get the view frame in screen coordinates.
+	var boundsInScreenCoordinates: CGRect? {
+		return window?.convertToScreen(convert(bounds, to: nil))
+	}
+}

--- a/Gifski/util.swift
+++ b/Gifski/util.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import AVFoundation
+import class Quartz.QLPreviewPanel
 
 /**
 Convenience function for initializing an object and modifying its properties
@@ -2110,5 +2111,15 @@ extension BinaryFloatingPoint {
 		var divisor: Self = 1
 		for _ in 0..<decimalPlaces { divisor *= 10 }
 		return (self * divisor).rounded(rule) / divisor
+	}
+}
+
+extension QLPreviewPanel {
+	func toggle() {
+		if isVisible {
+			orderOut(nil)
+		} else {
+			makeKeyAndOrderFront(nil)
+		}
 	}
 }


### PR DESCRIPTION
Resolves #66.

Hey @sindresorhus, first of all thanks for this awesome tool. I'm using it on a daily basis and finally I'm able to help out. I'm gonna do more improvements some time in the future as well.

This PR introduces QuickLook addition and fixes one crash (I've added a comment on the line). See some screenshots below and play with the branch yourself!

Also, let me know what documentation would you like me to add in this PR as well.

## QuickLook disabled as there is no GIF yet
<img width="536" alt="Zrzut ekranu 2019-05-7 o 12 33 52" src="https://user-images.githubusercontent.com/5232779/57295364-99f22a00-70ca-11e9-9b8e-fc46301b60a4.png">

## QuickLook disabled as the GIF is converting still
<img width="536" alt="Zrzut ekranu 2019-05-7 o 12 34 14" src="https://user-images.githubusercontent.com/5232779/57295367-9bbbed80-70ca-11e9-9202-7cadd17d1eb7.png">

## QuickLook enabled as we finished converting
<img width="540" alt="Zrzut ekranu 2019-05-7 o 12 34 37" src="https://user-images.githubusercontent.com/5232779/57295374-9eb6de00-70ca-11e9-86df-86e6e342c55f.png">

## QuickLook opened
<img width="547" alt="Zrzut ekranu 2019-05-7 o 12 35 43" src="https://user-images.githubusercontent.com/5232779/57295376-a1b1ce80-70ca-11e9-8890-e1a72d5841ad.png">