### PR TITLE
Add a system service for Gifski

### DIFF
--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -24,6 +24,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 		hasFinishedLaunching = true
 		NSApplication.shared.isAutomaticCustomizeTouchBarMenuItemEnabled = true
+		NSApp.servicesProvider = self
 
 		if urlsToConvertOnLaunch != nil {
 			mainWindowController.convert(urlsToConvertOnLaunch)
@@ -62,5 +63,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func application(_ application: NSApplication, willPresentError error: Error) -> Error {
 		Crashlytics.recordNonFatalError(error: error)
 		return error
+	}
+
+	/// This is called from NSApp as a service resolver
+	@objc
+	func convertToGif(_ pasteboard: NSPasteboard, userData: String, error: NSErrorPointer) {
+		guard let url = pasteboard.fileURLs().first else {
+			return
+		}
+
+		mainWindowController.convert(url)
 	}
 }

--- a/Gifski/AppDelegate.swift
+++ b/Gifski/AppDelegate.swift
@@ -64,7 +64,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		Crashlytics.recordNonFatalError(error: error)
 		return error
 	}
+}
 
+extension AppDelegate {
 	/// This is called from NSApp as a service resolver
 	@objc
 	func convertToGif(_ pasteboard: NSPasteboard, userData: String, error: NSErrorPointer) {

--- a/Gifski/Info.plist
+++ b/Gifski/Info.plist
@@ -33,13 +33,15 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Gifski: Convert to GIF</string>
+				<string>Convert to GIF with Gifski</string>
 			</dict>
 			<key>NSRequiredContext</key>
 			<dict/>
 			<key>NSSendFileTypes</key>
 			<array>
-				<string>public.movie</string>
+				<string>public.mpeg-4</string>
+				<string>com.apple.m4v-video</string>
+				<string>com.apple.quicktime-movie</string> 
 			</array>
 		</dict>
 	</array>

--- a/Gifski/Info.plist
+++ b/Gifski/Info.plist
@@ -23,6 +23,26 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMessage</key>
+			<string>convertToGif</string>
+			<key>NSPortName</key>
+			<string>Gifski</string>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Gifski: Convert to GIF</string>
+			</dict>
+			<key>NSRequiredContext</key>
+			<dict/>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.movie</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/maintaining.md
+++ b/maintaining.md
@@ -1,32 +1,30 @@
-## Maintaining Gifski
+## Maintaining
 
 ### Testing system services
 
 First, we need to install the app:
 1. Archive the app.
-1. Once you have your archive in the Organizer window, right-click on it and click **Show in Finder**.
-1. Right-click again, now on the latest `Gifski_DATE_.xcarchive` and click **Show package contents**.
-1. Open `/Products/Applications` and move `Gifski.app` to your `Applications` folder.
+2. Once you have your archive in the Organizer window, right-click it, and click **Show in Finder**.
+3. Right-click again, now on the latest `Gifski_DATE_.xcarchive`, and click **Show Package Contents**.
+4. Open `/Products/Applications` and move `Gifski.app` to your `Applications` directory.
 
 Then, we need to check if our system has the latest service installed:
 1. In your terminal, enter the command:
 ```bash
 /System/Library/CoreServices/pbs -dump | grep Gifski.app
 ```
-1. If you see `NSBundlePath = "/Applications/Gifski.app”` - you're good to go.
-1. If you don't see the line above, try updating the cache using command:
+2. If you see `NSBundlePath = "/Applications/Gifski.app”` - you're good to go.
+3. If you don't see the line above, try updating the cache:
 ```bash
 /System/Library/CoreServices/pbs -update
 ```
 
-Now make sure you have enabled the service in your settings:
-1. Go to your **System Preferences** -> **Keyboard**.
-1. Now click on the **Shortcuts** tab at the top.
-1. On the left panel select `Services` and on the right panel search for `Convert to Gif with Gifski` service - enable it.
+Now make sure you have enabled the service.
 
 ### Troubleshooting system services
 
 Sometimes the service doesn't work and it's really hard to understand why without any tools. You can use a debug flag on the instance of `Finder` app and see the logs it dumps:
+
 ```bash
 /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder -NSDebugServices com.sindresorhus.Gifski
 ```

--- a/maintaining.md
+++ b/maintaining.md
@@ -19,8 +19,6 @@ Then, we need to check if our system has the latest service installed:
 /System/Library/CoreServices/pbs -update
 ```
 
-Now make sure you have enabled the service.
-
 ### Troubleshooting system services
 
 Sometimes the service doesn't work and it's really hard to understand why without any tools. You can use a debug flag on the instance of `Finder` app and see the logs it dumps:

--- a/maintaining.md
+++ b/maintaining.md
@@ -23,3 +23,10 @@ Now make sure you have enabled the service in your settings:
 1. Go to your **System Preferences** -> **Keyboard**.
 1. Now click on the **Shortcuts** tab at the top.
 1. On the left panel select `Services` and on the right panel search for `Convert to Gif with Gifski` service - enable it.
+
+### Troubleshooting system services
+
+Sometimes the service doesn't work and it's really hard to understand why without any tools. You can use a debug flag on the instance of `Finder` app and see the logs it dumps:
+```bash
+/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder -NSDebugServices com.sindresorhus.Gifski
+```

--- a/maintaining.md
+++ b/maintaining.md
@@ -1,0 +1,25 @@
+## Maintaining Gifski
+
+### Testing system services
+
+First, we need to install the app:
+1. Archive the app.
+1. Once you have your archive in the Organizer window, right-click on it and click **Show in Finder**.
+1. Right-click again, now on the latest `Gifski_DATE_.xcarchive` and click **Show package contents**.
+1. Open `/Products/Applications` and move `Gifski.app` to your `Applications` folder.
+
+Then, we need to check if our system has the latest service installed:
+1. In your terminal, enter the command:
+```bash
+/System/Library/CoreServices/pbs -dump | grep Gifski.app
+```
+1. If you see `NSBundlePath = "/Applications/Gifski.app”` - you're good to go.
+1. If you don't see the line above, try updating the cache using command:
+```bash
+/System/Library/CoreServices/pbs -update
+```
+
+Now make sure you have enabled the service in your settings:
+1. Go to your **System Preferences** -> **Keyboard**.
+1. Now click on the **Shortcuts** tab at the top.
+1. On the left panel select `Services` and on the right panel search for `Convert to Gif with Gifski` service - enable it.

--- a/readme.md
+++ b/readme.md
@@ -25,14 +25,7 @@ Requires macOS 10.13 or later.
 
 ## System service
 
-Gifski provides a [system service](https://www.computerworld.com/article/2476298/os-x-a-quick-guide-to-services-on-your-mac.html) that lets you quickly convert a video to GIF from anywhere.
-
-You first have to enable it:
-
-1. Go to **System Preferences…** → **Keyboard**.
-2. Click the **Shortcuts** tab at the top.
-3. In the left panel, select **Services**.
-4. In the right panel, look for the **Convert to GIF with Gifski** service and click its checkbox.
+Gifski includes a [system service](https://www.computerworld.com/article/2476298/os-x-a-quick-guide-to-services-on-your-mac.html) that lets you quickly convert a video to GIF from the **Services** menu in any app that provides a compatible video file.
 
 
 ## Screenshots

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,13 @@ Requires macOS 10.13 or later.
 
 [![](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/macappstore-lrg.svg)](https://itunes.apple.com/no/app/gifski/id1351639930?mt=12)
 
+## Gifski system service
+
+If you want to be able to quickly convert your video to GIF using system service, you need to enable it first.
+1. Go to your **System Preferences** -> **Keyboard**.
+1. Now click on the **Shortcuts** tab at the top.
+1. On the left panel select `Services` and on the right panel search for `Convert to Gif with Gifski` service - enable it.
+
 
 ## Screenshots
 

--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,17 @@ Requires macOS 10.13 or later.
 
 [![](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/macappstore-lrg.svg)](https://itunes.apple.com/no/app/gifski/id1351639930?mt=12)
 
-## Gifski system service
 
-If you want to be able to quickly convert your video to GIF using system service, you need to enable it first.
-1. Go to your **System Preferences** -> **Keyboard**.
-1. Now click on the **Shortcuts** tab at the top.
-1. On the left panel select `Services` and on the right panel search for `Convert to Gif with Gifski` service - enable it.
+## System service
+
+Gifski provides a [system service](https://www.computerworld.com/article/2476298/os-x-a-quick-guide-to-services-on-your-mac.html) that lets you quickly convert a video to GIF from anywhere.
+
+You first have to enable it:
+
+1. Go to **System Preferences…** → **Keyboard**.
+2. Click the **Shortcuts** tab at the top.
+3. In the left panel, select **Services**.
+4. In the right panel, look for the **Convert to GIF with Gifski** service and click its checkbox.
 
 
 ## Screenshots


### PR DESCRIPTION
Resolves #47.

How to test it:
1. Archive the app, move it to `/Application` folder
2. In terminal make sure you have the service installed:
  a) `/System/Library/CoreServices/pbs -dump | grep Gifski.app`
  b) If you don’t see `NSBundlePath = "/Applications/Gifski.app”;`, try refreshing using `/System/Library/CoreServices/pbs -update`
3. Go to settings -> keyboard -> shortcuts -> services and enable `Gifski: Convert to GIF`

<details><summary>Sneak peak</summary>
<img src="https://user-images.githubusercontent.com/5232779/57307713-59ec7080-70e5-11e9-87dc-70ce1a404cc7.gif" />
</details>
